### PR TITLE
Corrected name of header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-#Language Translator
-##Group: Yuletide
+#Pet Food
+##Group: JSONx2andJENx1
 -Jason @github/jtreplogle
 -Jen Solima @github/craftylildev
 -Jason Weakley @github/JasonWeakley


### PR DESCRIPTION
I am slow to catch my editorial mistakes this morning.

I've changed the name of the H1 for the README file to be the correct group name.
